### PR TITLE
add compressed file support

### DIFF
--- a/PackagesInstallation.sh
+++ b/PackagesInstallation.sh
@@ -10,4 +10,5 @@ pip install --user \
   dpkt \
   pypcap \
   netaddr \
-  dnslib
+  dnslib \
+  pylzma


### PR DESCRIPTION
Many organizations store their pcap in compressed format. This commit adds support for files with these compression types: bzip2, gzip, xz, and zip.
